### PR TITLE
- properly encoded delayed option arguments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "GPL-2.0",
   "require": {
     "php": ">=5.4.0",
-    "videlalvaro/php-amqplib": "2.4.*"
+    "php-amqplib/php-amqplib": "2.6.*"
   },
   "require-dev": {
     "laravel/framework": ">=4.0.0",

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
     "php-amqplib/php-amqplib": "2.6.*"
   },
   "require-dev": {
-    "laravel/framework": ">=4.0.0",
+    "laravel/framework": ">=5.3.0",
     "squizlabs/php_codesniffer": "1.*",
-    "orchestra/testbench": "3.0.4",
+    "orchestra/testbench": "3.3.*",
     "phpunit/phpunit": "4.3.*"
   },
   "autoload": {

--- a/src/Connectors/AmqpConnector.php
+++ b/src/Connectors/AmqpConnector.php
@@ -4,7 +4,7 @@ namespace Forumhouse\LaravelAmqp\Connectors;
 
 use Forumhouse\LaravelAmqp\Queue\AMQPQueue;
 use Illuminate\Queue\Connectors\ConnectorInterface;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 /**
  * Class AmqpConnector
@@ -22,12 +22,21 @@ class AmqpConnector implements ConnectorInterface
      */
     public function connect(array $config)
     {
-        $connection = new AMQPConnection(
+        $connection = new AMQPStreamConnection(
             $config['host'],
             $config['port'],
             $config['user'],
             $config['password'],
-            isset($config['vhost']) ? $config['vhost'] : '/'
+            isset($config['vhost']) ? $config['vhost'] : '/',
+            false,
+            'AMQPLAIN',
+            null,
+            'en_US',
+            isset($config['connection_timeout']) ? $config['connection_timeout'] : 3,
+            isset($config['read_write_timeout']) ? $config['read_write_timeout'] : 3,
+            null,
+            isset($config['keepalive']) ? $config['keepalive'] : false,
+            isset($config['heartbeat']) ? $config['heartbeat'] : 0
         );
 
         if (!isset($config['exchange_type'])) {

--- a/src/Jobs/AMQPJob.php
+++ b/src/Jobs/AMQPJob.php
@@ -50,17 +50,11 @@ class AMQPJob extends Job implements \Illuminate\Contracts\Queue\Job
      */
     public function fire()
     {
-        $this->resolveAndFire(json_decode($this->amqpMessage->body, true));
-    }
-
-    /**
-     * Get the raw body string for the job.
-     *
-     * @return string
-     */
-    public function getRawBody()
-    {
-        return $this->amqpMessage->body;
+        $payload = json_decode($this->amqpMessage->body, true);
+        if (is_null($payload))
+            $this->delete();
+        else
+            $this->resolveAndFire($payload);
     }
 
     /**
@@ -75,13 +69,13 @@ class AMQPJob extends Job implements \Illuminate\Contracts\Queue\Job
     }
 
     /**
-     * Get queue name
+     * Get the raw body string for the job.
      *
      * @return string
      */
-    public function getQueue()
+    public function getRawBody()
     {
-        return $this->queue;
+        return $this->amqpMessage->body;
     }
 
     /**
@@ -125,6 +119,16 @@ class AMQPJob extends Job implements \Illuminate\Contracts\Queue\Job
         $body = json_decode($this->amqpMessage->body, true);
 
         return isset($body['data']['attempts']) ? $body['data']['attempts'] : 0;
+    }
+
+    /**
+     * Get queue name
+     *
+     * @return string
+     */
+    public function getQueue()
+    {
+        return $this->queue;
     }
 
     /**

--- a/src/Jobs/AMQPJob.php
+++ b/src/Jobs/AMQPJob.php
@@ -50,11 +50,10 @@ class AMQPJob extends Job implements \Illuminate\Contracts\Queue\Job
      */
     public function fire()
     {
-        $payload = json_decode($this->amqpMessage->body, true);
-        if (is_null($payload))
+        if (is_null($this->payload()))
             $this->delete();
         else
-            $this->resolveAndFire($payload);
+            $this->fire();
     }
 
     /**

--- a/src/Jobs/AMQPJob.php
+++ b/src/Jobs/AMQPJob.php
@@ -42,31 +42,7 @@ class AMQPJob extends Job implements \Illuminate\Contracts\Queue\Job
         $this->amqpMessage = $amqpMessage;
         $this->channel = $channel;
     }
-
-    /**
-     * Fire the job.
-     *
-     * @return void
-     */
-    public function fire()
-    {
-        if (is_null($this->payload()))
-            $this->delete();
-        else
-            $this->fire();
-    }
-
-    /**
-     * Delete the job from the queue.
-     *
-     * @return void
-     */
-    public function delete()
-    {
-        parent::delete();
-        $this->channel->basic_ack($this->amqpMessage->delivery_info['delivery_tag']);
-    }
-
+    
     /**
      * Get the raw body string for the job.
      *
@@ -106,6 +82,17 @@ class AMQPJob extends Job implements \Illuminate\Contracts\Queue\Job
         } else {
             $queue->push($job, $data, $this->getQueue());
         }
+    }
+
+    /**
+     * Delete the job from the queue.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        parent::delete();
+        $this->channel->basic_ack($this->amqpMessage->delivery_info['delivery_tag']);
     }
 
     /**

--- a/src/Queue/AMQPQueue.php
+++ b/src/Queue/AMQPQueue.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Queue;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 
@@ -61,7 +62,7 @@ class AMQPQueue extends Queue implements QueueContract
     private $messageProperties;
 
     /**
-     * @param AMQPConnection $connection
+     * @param AMQPStreamConnection $connection
      * @param string         $defaultQueueName  Default queue name
      * @param array          $queueFlags        Queue flags See a list of parameters to
      *                                          \PhpAmqpLib\Channel\AMQPChannel::queue_declare. Parameters should be
@@ -74,7 +75,7 @@ class AMQPQueue extends Queue implements QueueContract
      * @param mixed          $exchangeFlags     Exchange flags
      */
     public function __construct(
-        AMQPConnection $connection,
+        AMQPStreamConnection $connection,
         $defaultQueueName = null,
         $queueFlags = [],
         $messageProperties = [],

--- a/src/Queue/AMQPQueue.php
+++ b/src/Queue/AMQPQueue.php
@@ -310,4 +310,14 @@ class AMQPQueue extends Queue implements QueueContract
 
         return null;
     }
+
+    /**
+     * Get the size of the queue.
+     *
+     * @param  string $queue
+     * @return int
+     */
+    public function size($queue = null)
+    {
+    }
 }

--- a/src/Queue/AMQPQueue.php
+++ b/src/Queue/AMQPQueue.php
@@ -5,11 +5,12 @@ namespace Forumhouse\LaravelAmqp\Queue;
 use Forumhouse\LaravelAmqp\Exception\AMQPException;
 use Forumhouse\LaravelAmqp\Jobs\AMQPJob;
 use Forumhouse\LaravelAmqp\Utility\ArrayUtil;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Queue;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Message\AMQPMessage;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
+use PhpAmqpLib\Wire\AMQPTable;
 
 /**
  * Class representing AMQP Queue
@@ -96,6 +97,32 @@ class AMQPQueue extends Queue implements QueueContract
     }
 
     /**
+     * @param string $exchangeName The name of the exchange. For example, 'logs'
+     * @param string $exchangeType The type of the exchange. See EXCHANGE_TYPE_* constants for details
+     * @param array $exchangeFlags The flags of the exchange. See \PhpAmqpLib\Channel\AMQPChannel::exchange_declare
+     *                              (from third parameter onwards). Must be an assoc array. Default flags can be omitted
+     *
+     * @see \PhpAmqpLib\Channel\AMQPChannel::exchange_declare
+     * @return void
+     */
+    protected function declareExchange($exchangeName, $exchangeType, array $exchangeFlags = [])
+    {
+        $flags = array_replace([
+            'exchange' => $exchangeName,
+            'type' => $exchangeType,
+            'passive' => false,
+            'durable' => false,
+            'auto_delete' => true,
+            'internal' => false,
+            'nowait' => false,
+            'arguments' => null,
+            'ticket' => null,
+        ], $exchangeFlags);
+
+        call_user_func_array([$this->channel, 'exchange_declare'], $flags);
+    }
+
+    /**
      * Push a new job onto the queue.
      *
      * @param  string $job   Job implementation class name
@@ -112,6 +139,77 @@ class AMQPQueue extends Queue implements QueueContract
         $payload = new AMQPMessage($this->createPayload($job, $data), $this->messageProperties);
         $this->channel->basic_publish($payload, $this->exchangeName, $this->getRoutingKey($queue));
         return true;
+    }
+
+    /**
+     * Helper to return a default queue name in case passed param is empty
+     *
+     * @param string|null $name Queue name. If null, default will be used
+     *
+     * @throws AMQPException
+     * @return string Queue name to be used in AMQP calls
+     */
+    protected function getQueueName($name)
+    {
+        $name = $name ?: $this->defaultQueueName;
+        if ($name === null) {
+            throw new AMQPException('Default nor specific queue names given');
+        }
+        return $name;
+    }
+
+    /**
+     * Declares a queue to the AMQP library
+     *
+     * @param string $name The name of the queue to declare
+     *
+     * @return void
+     */
+    public function declareQueue($name)
+    {
+        $queue = $this->getQueueName($name);
+        $flags = array_replace_recursive([
+            'queue' => $queue,
+            'passive' => false,
+            'durable' => false,
+            'exclusive' => false,
+            'auto_delete' => true,
+            'nowait' => false,
+            'arguments' => null,
+            'ticket' => null,
+        ], $this->getQueueFlags($name));
+
+        call_user_func_array([$this->channel, 'queue_declare'], $flags);
+    }
+
+    /**
+     * @param string $queueName
+     * @param null|string $deferredQueueName
+     * @param null|int $deferredQueueDelay
+     *
+     * @return array
+     */
+    protected function getQueueFlags($queueName, $deferredQueueName = null, $deferredQueueDelay = null)
+    {
+        $args = func_get_args();
+        $result = ArrayUtil::arrayMapRecursive(function ($value) use ($args) {
+            return is_callable($value) ? call_user_func_array($value, $args) : $value;
+        }, $this->queueFlags);
+
+        $result = ArrayUtil::removeNullsRecursive($result);
+
+        return $result;
+    }
+
+    /**
+     *  Get routing key from config or use default one (queue name)
+     *
+     * @param $queue string
+     * @return string Routing key name
+     */
+    protected function getRoutingKey($queue)
+    {
+        return empty($this->queueFlags['routing_key']) ? $queue : $this->queueFlags['routing_key'];
     }
 
     /**
@@ -158,76 +256,6 @@ class AMQPQueue extends Queue implements QueueContract
     }
 
     /**
-     * Pop the next job off of the queue.
-     *
-     * @param string|null $queue Queue name if different from the default one
-     *
-     * @return \Illuminate\Queue\Jobs\Job|null Job instance or null if no unhandled jobs available
-     */
-    public function pop($queue = null)
-    {
-        $queue = $this->getQueueName($queue);
-        $this->declareQueue($queue);
-        $envelope = $this->channel->basic_get($queue);
-
-        if ($envelope instanceof AMQPMessage) {
-            return new AMQPJob($this->container, $queue, $this->channel, $envelope);
-        }
-
-        return null;
-    }
-
-    /**
-     * @param string $exchangeName  The name of the exchange. For example, 'logs'
-     * @param string $exchangeType  The type of the exchange. See EXCHANGE_TYPE_* constants for details
-     * @param array  $exchangeFlags The flags of the exchange. See \PhpAmqpLib\Channel\AMQPChannel::exchange_declare
-     *                              (from third parameter onwards). Must be an assoc array. Default flags can be omitted
-     *
-     * @see \PhpAmqpLib\Channel\AMQPChannel::exchange_declare
-     * @return void
-     */
-    protected function declareExchange($exchangeName, $exchangeType, array $exchangeFlags = [])
-    {
-        $flags = array_replace([
-            'exchange' => $exchangeName,
-            'type' => $exchangeType,
-            'passive' => false,
-            'durable' => false,
-            'auto_delete' => true,
-            'internal' => false,
-            'nowait' => false,
-            'arguments' => null,
-            'ticket' => null,
-        ], $exchangeFlags);
-
-        call_user_func_array([$this->channel, 'exchange_declare'], $flags);
-    }
-
-    /**
-     * Declares a queue to the AMQP library
-     *
-     * @param string $name The name of the queue to declare
-     *
-     * @return void
-     */
-    public function declareQueue($name)
-    {
-        $queue = $this->getQueueName($name);
-        $flags = array_replace_recursive([
-            'queue' => $queue,
-            'passive' => false,
-            'durable' => false,
-            'exclusive' => false,
-            'auto_delete' => true,
-            'nowait' => false,
-            'arguments' => null,
-            'ticket' => null,
-        ], $this->getQueueFlags($name));
-
-        call_user_func_array([$this->channel, 'queue_declare'], $flags);
-    }
-
-    /**
      * Declares delayed queue to the AMQP library
      *
      * @param string $destinationQueueName Queue destination
@@ -252,11 +280,11 @@ class AMQPQueue extends Queue implements QueueContract
         ], $this->getQueueFlags($destinationQueueName, $deferredQueueName, $delay), [
             'queue' => $deferredQueueName,
             'durable' => true,
-            'arguments' => [
-                'x-dead-letter-exchange' => ['S', ''],
-                'x-dead-letter-routing-key' => ['S', $destinationQueueName],
-                'x-message-ttl' => ['I', $delay * 1000],
-            ],
+            'arguments' => new AMQPTable([
+                'x-dead-letter-exchange' => '',
+                'x-dead-letter-routing-key' => $destinationQueueName,
+                'x-message-ttl' => $delay * 1000,
+            ]),
         ]);
 
         call_user_func_array([$this->channel, 'queue_declare'], $flags);
@@ -264,49 +292,22 @@ class AMQPQueue extends Queue implements QueueContract
     }
 
     /**
-     * Helper to return a default queue name in case passed param is empty
+     * Pop the next job off of the queue.
      *
-     * @param string|null $name Queue name. If null, default will be used
+     * @param string|null $queue Queue name if different from the default one
      *
-     * @throws AMQPException
-     * @return string Queue name to be used in AMQP calls
+     * @return \Illuminate\Queue\Jobs\Job|null Job instance or null if no unhandled jobs available
      */
-    protected function getQueueName($name)
+    public function pop($queue = null)
     {
-        $name = $name ?: $this->defaultQueueName;
-        if ($name === null) {
-            throw new AMQPException('Default nor specific queue names given');
+        $queue = $this->getQueueName($queue);
+        $this->declareQueue($queue);
+        $envelope = $this->channel->basic_get($queue);
+
+        if ($envelope instanceof AMQPMessage) {
+            return new AMQPJob($this->container, $queue, $this->channel, $envelope);
         }
-        return $name;
-    }
 
-    /**
-     *  Get routing key from config or use default one (queue name)
-     *
-     * @param $queue string
-     * @return string Routing key name
-     */
-    protected function getRoutingKey($queue)
-    {
-        return empty($this->queueFlags['routing_key']) ? $queue : $this->queueFlags['routing_key'];
-    }
-
-    /**
-     * @param string      $queueName
-     * @param null|string $deferredQueueName
-     * @param null|int    $deferredQueueDelay
-     *
-     * @return array
-     */
-    protected function getQueueFlags($queueName, $deferredQueueName = null, $deferredQueueDelay = null)
-    {
-        $args = func_get_args();
-        $result = ArrayUtil::arrayMapRecursive(function ($value) use($args) {
-            return is_callable($value) ? call_user_func_array($value, $args) : $value;
-        }, $this->queueFlags);
-
-        $result = ArrayUtil::removeNullsRecursive($result);
-
-        return $result;
+        return null;
     }
 }


### PR DESCRIPTION
properly encoded delayed option arguments (avoid AMQPProtocolChannelException: PRECONDITION_FAILED - invalid arg 'x-message-ttl' with delay more than 2147483 seconds or about 24 days)

we should use AMQPTable class to encode queue arguments otherwise integer values will be encoded as signed integer and it will reduce maximum TTL value from about 49 days to 24 days (max value of unsinged integer to max value of signed integer)
